### PR TITLE
Adjusting lint name/code

### DIFF
--- a/lints/lint_atis_pem_certificate_chain.go
+++ b/lints/lint_atis_pem_certificate_chain.go
@@ -13,7 +13,7 @@ const pemCertificateChain_details = "ATIS-1000080 separately indicates that the 
 
 func init() {
 	lint.RegisterRule(&lint.LintRule{
-		Code:        "w_aits_pem_certificate_chain",
+		Code:        "w_atis_pem_certificate_chain",
 		Description: pemCertificateChain_details,
 		Source:      lint.Atis1000080Source,
 		Rule:        NewPemCertificateChain,


### PR DESCRIPTION
Lint code presently reads as "w_aits_pem_certificate_chain".  Virtually certain that "w_atis_pem_certificate_chain" was intended.