### PR TITLE
Migrate understandingwebpki.com to x509.io

### DIFF
--- a/cmd/shaken/cmd_lint_print.go
+++ b/cmd/shaken/cmd_lint_print.go
@@ -205,7 +205,7 @@ func PrintCertificateReport(w io.Writer, r *LintCommandItem) {
 		fmt.Fprintln(w)
 	}
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "[View certificate details](https://understandingwebpki.com/?cert=%s)\n", url.QueryEscape(base64.StdEncoding.EncodeToString(r.Certificate.Raw)))
+	fmt.Fprintf(w, "[View certificate details](https://x509.io/?cert=%s)\n", url.QueryEscape(base64.StdEncoding.EncodeToString(r.Certificate.Raw)))
 	fmt.Fprintln(w)
 
 	if r.CertificateResult.HasProblems() {


### PR DESCRIPTION
https://understandingwebpki.com/ has been moved to https://x509.io/

According to:
https://twitter.com/rmhrisk/status/1721979059889168389
https://github.com/PeculiarVentures/pv-certificates-viewer
